### PR TITLE
Add category filter toggle and ChronoCrow project card

### DIFF
--- a/app/javascript/filter_projects.js
+++ b/app/javascript/filter_projects.js
@@ -1,32 +1,36 @@
 // Function to filter projects based on category and highlight the active button
 function filterProjects(category, element) {
-  // Get all project cards
   var projects = document.querySelectorAll('.project-card');
-  // Get all filter buttons
   var buttons = document.querySelectorAll('.filter-buttons .btn');
+  var message = document.getElementById('project-filter-message');
 
-  // Remove the active class from all buttons
   buttons.forEach(function(btn) {
     btn.classList.remove('active');
   });
 
-  // Add the active class to the clicked button
-  element.classList.add('active');
+  if (element) {
+    element.classList.add('active');
+  }
 
-  // Show or hide projects based on the selected category
+  if (message) {
+    message.style.display = 'none';
+  }
+
   projects.forEach(function(project) {
-    if (category === 'all') {
-      project.style.display = 'block'; // Show all projects
+    if (category && project.classList.contains(category)) {
+      project.style.display = 'block';
     } else {
-      // Show the project if it matches the selected category, otherwise hide it
-      if (project.classList.contains(category)) {
-        project.style.display = 'block'; // Show matching project
-      } else {
-        project.style.display = 'none'; // Hide non-matching project
-      }
+      project.style.display = 'none';
     }
   });
 }
 
 // Make the function globally accessible
 window.filterProjects = filterProjects;
+
+document.addEventListener('DOMContentLoaded', function() {
+  var projects = document.querySelectorAll('.project-card');
+  projects.forEach(function(project) {
+    project.style.display = 'none';
+  });
+});

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -29,22 +29,19 @@
         <h3 class="text-center">Featured Projects</h3>
         <!-- Filter Buttons -->
         <div class="filter-buttons text-center">
-          <button onclick="filterProjects('all', this)" class="btn btn-primary active">
-            <i class="fas fa-th"></i>
+          <button onclick="filterProjects('web', this)" class="btn btn-primary mx-1" aria-label="Show web projects">
+            <i class="fas fa-code"></i>
           </button>
-          <button onclick="filterProjects('javascript', this)" class="btn btn-secondary">
-            <i class="fab fa-js-square"></i>
-          </button>
-          <button onclick="filterProjects('rails', this)" class="btn btn-secondary">
-            <i class="fas fa-gem"></i>
-          </button>
-          <button onclick="filterProjects('react', this)" class="btn btn-secondary">
-            <i class="fab fa-react"></i>
+          <button onclick="filterProjects('game', this)" class="btn btn-primary mx-1" aria-label="Show game projects">
+            <i class="fas fa-gamepad"></i>
           </button>
         </div>
+        <p class="text-center text-muted mt-3" id="project-filter-message">
+          Select Web or Game to explore featured work.
+        </p>
         <div class="row justify-content-center">
           <!-- Raspberry Pi Server Card -->
-          <div class="col-md-4 mt-3 rails project-card d-flex">
+          <div class="col-md-4 mt-3 web project-card d-flex">
             <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
               <!-- Image Container -->
               <div style="height: 500px; overflow: hidden;">
@@ -75,7 +72,7 @@
       </div>
 
       <!-- CelebrantGPT Card -->
-      <div class="col-md-4 mt-3 rails project-card d-flex">
+      <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
           <div style="height: 500px; overflow: hidden;">
             <img
@@ -105,7 +102,7 @@
       </div>
 
       <!-- ChoreQuest Card -->
-      <div class="col-md-4 mt-3 rails project-card d-flex">
+      <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
           <div style="height: 500px; overflow: hidden;">
             <img
@@ -134,7 +131,7 @@
       </div>
 
       <!-- Three.js Portfolio Card -->
-      <div class="col-md-4 mt-3 react javascript project-card d-flex">
+      <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
           <div style="height: 500px; overflow: hidden;">
             <img
@@ -162,7 +159,7 @@
       </div>
 
       <!-- FigMax Card -->
-      <div class="col-md-4 mt-3 react javascript project-card d-flex">
+      <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
           <div style="height: 500px; overflow: hidden;">
             <img
@@ -192,7 +189,7 @@
       </div>
 
       <!-- Word Quest Card -->
-      <div class="col-md-4 mt-3 rails project-card d-flex">
+      <div class="col-md-4 mt-3 game project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
           <div style="height: 500px; overflow: hidden;">
             <img
@@ -210,11 +207,30 @@
             <div class="text-center mt-auto">
               <%= link_to 'Play Word Quest', new_game_path, class: 'btn btn-primary' %>
             </div>
-                </div>
-              </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ChronoCrow Card -->
+      <div class="col-md-4 mt-3 game project-card d-flex">
+        <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
+          <div style="height: 500px; overflow: hidden;">
+            <%= image_tag 'ChronoCrow.png', alt: 'ChronoCrow key art', style: 'width: 100%; height: 100%; object-fit: cover;' %>
+          </div>
+          <div class="card-body d-flex flex-column">
+            <h3 class="card-title text-center">ChronoCrow</h3>
+            <p class="card-text flex-grow-1 darker-p">
+              ChronoCrow is an atmospheric adventure that blends time-bending puzzles with fast-paced combat. Built with Unity,
+              it follows a mysterious crow navigating shifting timelines to restore balance to a fractured world.
+            </p>
+            <div class="text-center mt-auto">
+              <a href="#" class="btn btn-primary disabled" aria-disabled="true">ChronoCrow Coming Soon</a>
             </div>
+          </div>
+        </div>
+      </div>
         <!-- Time Tracker Card -->
-        <div class="col-md-4 mt-3 rails project-card d-flex">
+        <div class="col-md-4 mt-3 web project-card d-flex">
           <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
             <div style="height: 500px; overflow: hidden;">
               <img
@@ -240,7 +256,7 @@
           </div>
         </div>
         <!-- Stumped Album Card -->
-            <div class="col-md-4 mt-3 project-card d-flex">
+            <div class="col-md-4 mt-3 web project-card d-flex">
               <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
                 <div style="height: 500px; overflow: hidden;">
                   <img
@@ -283,7 +299,7 @@
   <div class="row justify-content-center align-items-stretch">
 
     <!-- Wordle Solver Chrome Extension Card -->
-    <div class="col-md-4 mt-3 project-card d-flex">
+    <div class="col-md-4 mt-3 web project-card d-flex">
       <!--
         1) Set a fixed height (e.g. 300px).
         2) Use flexbox to distribute space in column.
@@ -309,7 +325,7 @@
     </div>
 
     <!-- JS Puzzle Game Card -->
-    <div class="col-md-4 mt-3 project-card d-flex">
+    <div class="col-md-4 mt-3 game project-card d-flex">
       <div class="card mb-4 shadow-sm d-flex flex-column" style="height: 300px;">
         <div class="card-body d-flex flex-column">
           <h3 class="card-title text-center">JS Puzzle Game</h3>
@@ -330,7 +346,7 @@
     </div>
 
     <!-- Ajax Movie Search Card -->
-    <div class="col-md-4 mt-3 project-card d-flex">
+    <div class="col-md-4 mt-3 web project-card d-flex">
       <div class="card mb-4 shadow-sm d-flex flex-column" style="height: 300px;">
         <div class="card-body d-flex flex-column">
           <h3 class="card-title text-center">Ajax Movie Search</h3>


### PR DESCRIPTION
## Summary
- replace the featured project filter buttons with Web and Game toggles and show a prompt until one is selected
- update the filtering script to hide all projects by default and reveal cards that match the chosen category
- mark existing cards as web or game and introduce a ChronoCrow game card for testing the new filter

## Testing
- bin/rails test *(fails: Ruby version is 3.2.3 but Gemfile specifies 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d0daa6457c832a995cb59df80a88d4