### PR TITLE
Improve project filtering behavior

### DIFF
--- a/app/javascript/filter_projects.js
+++ b/app/javascript/filter_projects.js
@@ -3,6 +3,7 @@ function filterProjects(category, element) {
   var projects = document.querySelectorAll('.project-card');
   var buttons = document.querySelectorAll('.filter-buttons .btn');
   var message = document.getElementById('project-filter-message');
+  var hasVisibleProject = false;
 
   buttons.forEach(function(btn) {
     btn.classList.remove('active');
@@ -18,11 +19,21 @@ function filterProjects(category, element) {
 
   projects.forEach(function(project) {
     if (category && project.classList.contains(category)) {
-      project.style.display = 'block';
+      hasVisibleProject = true;
+      project.style.display = project.dataset.defaultDisplay || '';
     } else {
       project.style.display = 'none';
     }
   });
+
+  if (message) {
+    if (hasVisibleProject) {
+      message.style.display = 'none';
+    } else {
+      message.style.display = '';
+      message.textContent = 'No projects available for this category yet. Check back soon!';
+    }
+  }
 }
 
 // Make the function globally accessible
@@ -31,6 +42,15 @@ window.filterProjects = filterProjects;
 document.addEventListener('DOMContentLoaded', function() {
   var projects = document.querySelectorAll('.project-card');
   projects.forEach(function(project) {
+    if (!project.dataset.defaultDisplay) {
+      project.dataset.defaultDisplay = window.getComputedStyle(project).display;
+    }
     project.style.display = 'none';
   });
+
+  var message = document.getElementById('project-filter-message');
+  if (message) {
+    message.style.display = '';
+    message.textContent = 'Select Web or Game to explore featured work.';
+  }
 });

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -189,7 +189,7 @@
       </div>
 
       <!-- Word Quest Card -->
-      <div class="col-md-4 mt-3 game project-card d-flex">
+      <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
           <div style="height: 500px; overflow: hidden;">
             <img


### PR DESCRIPTION
## Summary
- ensure project cards stay hidden until a filter is chosen and restore their intended layout when revealed
- surface a helpful message when a category has no matching projects and reset the default prompt on page load
- reclassify Word Quest as a web project so the Game filter only shows ChronoCrow

## Testing
- bin/rails test *(fails: Ruby version 3.2.3 does not satisfy Gemfile requirement 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e1f513fc832aaede3c9a78a5693f