### PR TITLE
Ensure project filters hide cards with helper class

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,7 +15,11 @@
  *= require word_game
  */
 
- @import "bootstrap";
+@import "bootstrap";
+
+.project-hidden {
+  display: none !important;
+}
 
  body {
   font-family: Arial, sans-serif;

--- a/app/javascript/filter_projects.js
+++ b/app/javascript/filter_projects.js
@@ -20,9 +20,9 @@ function filterProjects(category, element) {
   projects.forEach(function(project) {
     if (category && project.classList.contains(category)) {
       hasVisibleProject = true;
-      project.style.display = project.dataset.defaultDisplay || '';
+      project.classList.remove('project-hidden');
     } else {
-      project.style.display = 'none';
+      project.classList.add('project-hidden');
     }
   });
 
@@ -42,10 +42,7 @@ window.filterProjects = filterProjects;
 document.addEventListener('DOMContentLoaded', function() {
   var projects = document.querySelectorAll('.project-card');
   projects.forEach(function(project) {
-    if (!project.dataset.defaultDisplay) {
-      project.dataset.defaultDisplay = window.getComputedStyle(project).display;
-    }
-    project.style.display = 'none';
+    project.classList.add('project-hidden');
   });
 
   var message = document.getElementById('project-filter-message');


### PR DESCRIPTION
## Summary
- replace inline display toggling in the project filter with a helper class that survives Bootstrap display utilities
- add a .project-hidden helper utility with display: none !important so cards stay hidden until shown by filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0e46884ac832a9185fdb9b4ed253c