### PR TITLE
Stabilize project filter visibility and fade animations

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,7 +15,22 @@
  *= require word_game
  */
 
- @import "bootstrap";
+@import "bootstrap";
+
+.project-hidden {
+  display: none !important;
+}
+
+.filter-fade-target {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.filter-fade-visible {
+  opacity: 1;
+  transform: none;
+}
 
  body {
   font-family: Arial, sans-serif;

--- a/app/javascript/filter_projects.js
+++ b/app/javascript/filter_projects.js
@@ -1,8 +1,53 @@
+var scheduleFrame = (typeof window !== 'undefined' && window.requestAnimationFrame)
+  ? window.requestAnimationFrame.bind(window)
+  : function(callback) {
+      return setTimeout(callback, 16);
+    };
+
+function ensureFadeTarget(element) {
+  if (element && !element.classList.contains('filter-fade-target')) {
+    element.classList.add('filter-fade-target');
+  }
+}
+
+function showWithFade(element) {
+  if (!element) {
+    return;
+  }
+
+  ensureFadeTarget(element);
+
+  if (!element.classList.contains('project-hidden')) {
+    element.classList.add('filter-fade-visible');
+    return;
+  }
+
+  element.classList.remove('project-hidden');
+  element.classList.remove('filter-fade-visible');
+
+  scheduleFrame(function() {
+    element.classList.add('filter-fade-visible');
+  });
+}
+
+function hideWithFade(element) {
+  if (!element) {
+    return;
+  }
+
+  element.classList.remove('filter-fade-visible');
+
+  if (!element.classList.contains('project-hidden')) {
+    element.classList.add('project-hidden');
+  }
+}
+
 // Function to filter projects based on category and highlight the active button
 function filterProjects(category, element) {
   var projects = document.querySelectorAll('.project-card');
   var buttons = document.querySelectorAll('.filter-buttons .btn');
   var message = document.getElementById('project-filter-message');
+  var filterDependents = document.querySelectorAll('.filter-dependent');
   var hasVisibleProject = false;
 
   buttons.forEach(function(btn) {
@@ -18,13 +63,25 @@ function filterProjects(category, element) {
   }
 
   projects.forEach(function(project) {
+    ensureFadeTarget(project);
+
     if (category && project.classList.contains(category)) {
       hasVisibleProject = true;
-      project.style.display = project.dataset.defaultDisplay || '';
+      showWithFade(project);
     } else {
-      project.style.display = 'none';
+      hideWithFade(project);
     }
   });
+
+  if (category && hasVisibleProject) {
+    filterDependents.forEach(function(dependent) {
+      showWithFade(dependent);
+    });
+  } else {
+    filterDependents.forEach(function(dependent) {
+      hideWithFade(dependent);
+    });
+  }
 
   if (message) {
     if (hasVisibleProject) {
@@ -42,10 +99,16 @@ window.filterProjects = filterProjects;
 document.addEventListener('DOMContentLoaded', function() {
   var projects = document.querySelectorAll('.project-card');
   projects.forEach(function(project) {
-    if (!project.dataset.defaultDisplay) {
-      project.dataset.defaultDisplay = window.getComputedStyle(project).display;
-    }
-    project.style.display = 'none';
+    project.classList.add('project-hidden');
+    project.classList.remove('filter-fade-visible');
+    ensureFadeTarget(project);
+  });
+
+  var filterDependents = document.querySelectorAll('.filter-dependent');
+  filterDependents.forEach(function(element) {
+    element.classList.add('project-hidden');
+    element.classList.remove('filter-fade-visible');
+    ensureFadeTarget(element);
   });
 
   var message = document.getElementById('project-filter-message');

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -25,8 +25,8 @@
     </div>
     <!-- Featured Projects Section -->
     <section id="projects" class="container mt-5">
-      <div data-aos="fade-up" data-aos-duration="500" data-aos-delay="50" data-aos-easing="ease-in-out">
-        <h3 class="text-center">Featured Projects</h3>
+      <div>
+        <h3 class="text-center filter-dependent project-hidden filter-fade-target">Featured Projects</h3>
         <!-- Filter Buttons -->
         <div class="filter-buttons text-center">
           <button onclick="filterProjects('web', this)" class="btn btn-primary mx-1" aria-label="Show web projects">
@@ -39,7 +39,7 @@
         <p class="text-center text-muted mt-3" id="project-filter-message">
           Select Web or Game to explore featured work.
         </p>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center filter-dependent project-hidden filter-fade-target">
           <!-- Raspberry Pi Server Card -->
           <div class="col-md-4 mt-3 web project-card d-flex">
             <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
@@ -290,7 +290,7 @@
           </div>
         </section>
         <!-- Smaller Fun Projects Section -->
-<section id="smaller-projects" class="container mt-5">
+<section id="smaller-projects" class="container mt-5 filter-dependent project-hidden filter-fade-target">
   <h3 class="text-center">Smaller Fun Projects</h3>
   <!--
     Use align-items-stretch on the row to ensure columns (and thus cards)
@@ -371,7 +371,7 @@
 </section>
 
         <!-- Contact -->
-        <section id="contact" class="container my-5 pb-5 text-center">
+        <section id="contact" class="container my-5 pb-5 text-center filter-dependent project-hidden filter-fade-target">
           <div class="mb-5">
             <h3>Contact Me</h3>
             <div class="d-flex justify-content-center">


### PR DESCRIPTION
## Summary
- add fade utility classes and helper functions so project cards and dependent sections animate when the filter reveals them without fighting Bootstrap display utilities
- remove the scroll-driven fade attributes and mark dependent sections hidden by default so the filter buttons remain visible while content appears only after a selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0e46884ac832a9185fdb9b4ed253c