### PR TITLE
Add Chrono Crow WebGL page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,25 @@ class PagesController < ApplicationController
 
   def secrets
   end
+
+  def chrono_crow
+    public_root = Rails.root.join('public')
+    candidate_dir = Dir.glob(public_root.join('*')).find do |path|
+      File.directory?(path) && File.basename(path).downcase.include?('chronocrow')
+    end
+
+    chrono_dir = Pathname(candidate_dir || public_root.join('ChronoCrow'))
+    relative_root = chrono_dir.relative_path_from(public_root).to_s
+    @chronocrow_root_path = "/#{relative_root}".gsub(%r{//+}, '/')
+
+    build_dir = chrono_dir.join('Build')
+    loader_file = build_dir.exist? ? Dir.glob(build_dir.join('*.loader.js')).first : nil
+    build_basename = loader_file ? File.basename(loader_file, '.loader.js') : 'ChronoCrow'
+
+    @chronocrow_loader_path = File.join(@chronocrow_root_path, 'Build', "#{build_basename}.loader.js")
+    @chronocrow_data_path = File.join(@chronocrow_root_path, 'Build', "#{build_basename}.data")
+    @chronocrow_framework_path = File.join(@chronocrow_root_path, 'Build', "#{build_basename}.framework.js")
+    @chronocrow_wasm_path = File.join(@chronocrow_root_path, 'Build', "#{build_basename}.wasm")
+    @chronocrow_streaming_assets_path = File.join(@chronocrow_root_path, 'StreamingAssets')
+  end
 end

--- a/app/views/pages/chrono_crow.html.erb
+++ b/app/views/pages/chrono_crow.html.erb
@@ -1,0 +1,117 @@
+<div class="container py-5 chrono-crow-page">
+  <div class="row justify-content-center">
+    <div class="col-lg-10">
+      <h1 class="text-center mb-4">Chrono Crow</h1>
+      <p class="lead text-center text-muted mb-4">
+        Chrono Crow is an experimental endless runner made in Unity. Guide the time-travelling crow through temporal rifts,
+        dodge obstacles, and collect gears to charge your chrono dash.
+      </p>
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <div class="row">
+            <div class="col-lg-4 mb-4 mb-lg-0">
+              <h2 class="h5">How to Play</h2>
+              <ul class="list-unstyled small text-muted">
+                <li class="mb-2">Press the <strong>spacebar</strong> or <strong>left-click</strong> to flap.</li>
+                <li class="mb-2">Hold to glide and weave between anomalies.</li>
+                <li class="mb-2">Collect gears to build your chrono meter and unleash a burst of speed.</li>
+                <li>Hit an obstacle and the timeline resets—try for a better distance!</li>
+              </ul>
+            </div>
+            <div class="col-lg-8">
+              <link rel="stylesheet" href="<%= File.join(@chronocrow_root_path, 'TemplateData', 'style.css') %>">
+              <div id="unity-container" class="unity-desktop">
+                <canvas id="unity-canvas"></canvas>
+                <div id="unity-loading-bar">
+                  <div id="unity-logo"></div>
+                  <div id="unity-progress-bar-empty">
+                    <div id="unity-progress-bar-full"></div>
+                  </div>
+                </div>
+                <div id="unity-warning"></div>
+                <div id="unity-footer">
+                  <div id="unity-fullscreen-button"></div>
+                  <div id="unity-mobile-warning">WebGL builds are not supported on mobile devices.</div>
+                </div>
+              </div>
+              <script src="<%= @chronocrow_loader_path %>"></script>
+              <script>
+                const canvas = document.querySelector("#unity-canvas");
+                const container = document.querySelector("#unity-container");
+                const loadingBar = document.querySelector("#unity-loading-bar");
+                const progressBarFull = document.querySelector("#unity-progress-bar-full");
+                const fullscreenButton = document.querySelector("#unity-fullscreen-button");
+                const warningBanner = document.querySelector("#unity-warning");
+                warningBanner.style.display = 'none';
+
+                function updateBannerVisibility() {
+                  warningBanner.style.display = warningBanner.children.length ? 'block' : 'none';
+                }
+
+                function unityShowBanner(msg, type) {
+                  const div = document.createElement('div');
+                  div.innerHTML = msg;
+                  div.className = 'unity-banner ' + (type || '');
+                  warningBanner.appendChild(div);
+                  if (type === 'warning') {
+                    setTimeout(() => {
+                      warningBanner.removeChild(div);
+                      updateBannerVisibility();
+                    }, 5000);
+                  } else if (type === 'error') {
+                    div.addEventListener('click', () => {
+                      warningBanner.removeChild(div);
+                      updateBannerVisibility();
+                    });
+                  }
+                  updateBannerVisibility();
+                }
+
+                const config = {
+                  dataUrl: "<%= @chronocrow_data_path %>",
+                  frameworkUrl: "<%= @chronocrow_framework_path %>",
+                  codeUrl: "<%= @chronocrow_wasm_path %>",
+                  streamingAssetsUrl: "<%= @chronocrow_streaming_assets_path %>",
+                  companyName: 'Chrono Crow Team',
+                  productName: 'Chrono Crow',
+                  productVersion: '0.1',
+                  showBanner: unityShowBanner
+                };
+
+                if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
+                  container.className = 'unity-mobile';
+                  unityShowBanner('WebGL builds are not supported on mobile devices.', 'warning');
+                  config.devicePixelRatio = 1;
+                } else {
+                  canvas.style.maxWidth = '960px';
+                  canvas.style.width = '100%';
+                  canvas.style.height = '600px';
+                  canvas.style.margin = '0 auto';
+                }
+
+                loadingBar.style.display = 'block';
+
+                createUnityInstance(canvas, config, (progress) => {
+                  progressBarFull.style.width = 100 * progress + '%';
+                })
+                  .then((unityInstance) => {
+                    loadingBar.style.display = 'none';
+                    fullscreenButton.onclick = () => {
+                      unityInstance.SetFullscreen(1);
+                    };
+                  })
+                  .catch((message) => {
+                    unityShowBanner(message, 'error');
+                  });
+              </script>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="text-center text-muted small">
+        Having trouble loading the build? Try refreshing the page or clearing your browser cache. Unity WebGL builds can take
+        a moment to compile on first load.
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -220,11 +220,10 @@
           <div class="card-body d-flex flex-column">
             <h3 class="card-title text-center">ChronoCrow</h3>
             <p class="card-text flex-grow-1 darker-p">
-              ChronoCrow is an atmospheric adventure that blends time-bending puzzles with fast-paced combat. Built with Unity,
-              it follows a mysterious crow navigating shifting timelines to restore balance to a fractured world.
+              Chrono Crow is an in development flappy bird runner game about a time travelling crow.
             </p>
             <div class="text-center mt-auto">
-              <a href="#" class="btn btn-primary disabled" aria-disabled="true">ChronoCrow Coming Soon</a>
+              <%= link_to 'Play Chrono Crow', chrono_crow_path, class: 'btn btn-primary' %>
             </div>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get 'pages/home'
   get 'pages/secrets'
+  get 'chronocrow', to: 'pages#chrono_crow', as: :chrono_crow
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Summary
- add a dedicated Chrono Crow route and controller action that locates the Unity build assets
- build a Chrono Crow view that embeds the existing Unity WebGL build with instructions and loader markup
- update the Chrono Crow home card to link to the new page and refresh its description

## Testing
- bin/rails routes -g chrono *(fails: Ruby 3.2.3 present but Gemfile requires 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ef21c16c832a9f086058c7de2480