### PR TITLE
Revamp Chrono Crow layout for responsive Unity player

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,6 +151,85 @@ a:hover {
   background-color: #F8F9FA;
 }
 
+.chrono-crow-page {
+  background: radial-gradient(circle at top, rgba(19, 21, 34, 0.95) 0%, rgba(7, 8, 14, 0.98) 60%, #05060a 100%);
+}
+
+.chrono-crow-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 3vw, 3rem);
+  justify-content: center;
+  align-items: flex-start;
+  margin: 0 auto;
+  max-width: calc(1920px + 24rem);
+  padding: 0 clamp(1rem, 4vw, 3rem);
+}
+
+.chrono-crow-info {
+  flex: 0 1 22rem;
+  max-width: 24rem;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+  padding: clamp(1.5rem, 3vw, 2rem);
+}
+
+.chrono-crow-player {
+  flex: 1 1 40rem;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.chrono-crow-player-frame {
+  width: 100%;
+  max-width: 1920px;
+  aspect-ratio: 16 / 9;
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.35);
+  background: #000;
+  margin: 0 auto;
+}
+
+.chrono-crow-player-frame canvas {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+  background-color: #000;
+}
+
+.chrono-crow-player #unity-footer {
+  gap: 1rem;
+}
+
+.chrono-crow-rotate-tip {
+  background: rgba(13, 110, 253, 0.1);
+  border: 1px solid rgba(13, 110, 253, 0.25);
+  color: #b5d5ff;
+}
+
+@media (max-width: 1199.98px) {
+  .chrono-crow-player-frame {
+    border-radius: 0.75rem;
+    box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (max-width: 767.98px) {
+  .chrono-crow-info {
+    text-align: left;
+  }
+
+  .chrono-crow-player {
+    flex: 1 1 100%;
+  }
+}
+
 /* Dark Mode */
 body.dark-mode {
   background-color: #212529 !important;

--- a/app/views/pages/chrono_crow.html.erb
+++ b/app/views/pages/chrono_crow.html.erb
@@ -1,117 +1,143 @@
-<div class="container py-5 chrono-crow-page">
-  <div class="row justify-content-center">
-    <div class="col-lg-10">
-      <h1 class="text-center mb-4">Chrono Crow</h1>
-      <p class="lead text-center text-muted mb-4">
-        Chrono Crow is an experimental endless runner made in Unity. Guide the time-travelling crow through temporal rifts,
-        dodge obstacles, and collect gears to charge your chrono dash.
-      </p>
-      <div class="card shadow-sm mb-4">
-        <div class="card-body">
-          <div class="row">
-            <div class="col-lg-4 mb-4 mb-lg-0">
-              <h2 class="h5">How to Play</h2>
-              <ul class="list-unstyled small text-muted">
-                <li class="mb-2">Press the <strong>spacebar</strong> or <strong>left-click</strong> to flap.</li>
-                <li class="mb-2">Hold to glide and weave between anomalies.</li>
-                <li class="mb-2">Collect gears to build your chrono meter and unleash a burst of speed.</li>
-                <li>Hit an obstacle and the timeline resets—try for a better distance!</li>
-              </ul>
+<div class="chrono-crow-page py-5">
+  <div class="container-xl text-center mb-5">
+    <h1 class="mb-4">Chrono Crow</h1>
+    <p class="lead text-muted">
+      Chrono Crow is an experimental endless runner made in Unity. Guide the time-travelling crow through temporal rifts,
+      dodge obstacles, and collect gears to charge your chrono dash.
+    </p>
+  </div>
+  <div class="chrono-crow-layout container-fluid">
+    <div class="chrono-crow-info">
+      <h2 class="h5">How to Play</h2>
+      <ul class="list-unstyled small text-muted mb-4">
+        <li class="mb-2">Press the <strong>spacebar</strong> or <strong>left-click</strong> to flap.</li>
+        <li class="mb-2">Hold to glide and weave between anomalies.</li>
+        <li class="mb-2">Collect gears to build your chrono meter and unleash a burst of speed.</li>
+        <li>Hit an obstacle and the timeline resets—try for a better distance!</li>
+      </ul>
+      <div class="alert alert-info chrono-crow-rotate-tip">
+        Rotate your device for a full-width experience on mobile.
+      </div>
+    </div>
+    <div class="chrono-crow-player">
+      <link rel="stylesheet" href="<%= File.join(@chronocrow_root_path, 'TemplateData', 'style.css') %>">
+      <div class="chrono-crow-player-frame">
+        <div id="unity-container" class="unity-desktop">
+          <canvas id="unity-canvas"></canvas>
+          <div id="unity-loading-bar">
+            <div id="unity-logo"></div>
+            <div id="unity-progress-bar-empty">
+              <div id="unity-progress-bar-full"></div>
             </div>
-            <div class="col-lg-8">
-              <link rel="stylesheet" href="<%= File.join(@chronocrow_root_path, 'TemplateData', 'style.css') %>">
-              <div id="unity-container" class="unity-desktop">
-                <canvas id="unity-canvas"></canvas>
-                <div id="unity-loading-bar">
-                  <div id="unity-logo"></div>
-                  <div id="unity-progress-bar-empty">
-                    <div id="unity-progress-bar-full"></div>
-                  </div>
-                </div>
-                <div id="unity-warning"></div>
-                <div id="unity-footer">
-                  <div id="unity-fullscreen-button"></div>
-                  <div id="unity-mobile-warning">WebGL builds are not supported on mobile devices.</div>
-                </div>
-              </div>
-              <script src="<%= @chronocrow_loader_path %>"></script>
-              <script>
-                const canvas = document.querySelector("#unity-canvas");
-                const container = document.querySelector("#unity-container");
-                const loadingBar = document.querySelector("#unity-loading-bar");
-                const progressBarFull = document.querySelector("#unity-progress-bar-full");
-                const fullscreenButton = document.querySelector("#unity-fullscreen-button");
-                const warningBanner = document.querySelector("#unity-warning");
-                warningBanner.style.display = 'none';
-
-                function updateBannerVisibility() {
-                  warningBanner.style.display = warningBanner.children.length ? 'block' : 'none';
-                }
-
-                function unityShowBanner(msg, type) {
-                  const div = document.createElement('div');
-                  div.innerHTML = msg;
-                  div.className = 'unity-banner ' + (type || '');
-                  warningBanner.appendChild(div);
-                  if (type === 'warning') {
-                    setTimeout(() => {
-                      warningBanner.removeChild(div);
-                      updateBannerVisibility();
-                    }, 5000);
-                  } else if (type === 'error') {
-                    div.addEventListener('click', () => {
-                      warningBanner.removeChild(div);
-                      updateBannerVisibility();
-                    });
-                  }
-                  updateBannerVisibility();
-                }
-
-                const config = {
-                  dataUrl: "<%= @chronocrow_data_path %>",
-                  frameworkUrl: "<%= @chronocrow_framework_path %>",
-                  codeUrl: "<%= @chronocrow_wasm_path %>",
-                  streamingAssetsUrl: "<%= @chronocrow_streaming_assets_path %>",
-                  companyName: 'Chrono Crow Team',
-                  productName: 'Chrono Crow',
-                  productVersion: '0.1',
-                  showBanner: unityShowBanner
-                };
-
-                if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
-                  container.className = 'unity-mobile';
-                  unityShowBanner('WebGL builds are not supported on mobile devices.', 'warning');
-                  config.devicePixelRatio = 1;
-                } else {
-                  canvas.style.maxWidth = '960px';
-                  canvas.style.width = '100%';
-                  canvas.style.height = '600px';
-                  canvas.style.margin = '0 auto';
-                }
-
-                loadingBar.style.display = 'block';
-
-                createUnityInstance(canvas, config, (progress) => {
-                  progressBarFull.style.width = 100 * progress + '%';
-                })
-                  .then((unityInstance) => {
-                    loadingBar.style.display = 'none';
-                    fullscreenButton.onclick = () => {
-                      unityInstance.SetFullscreen(1);
-                    };
-                  })
-                  .catch((message) => {
-                    unityShowBanner(message, 'error');
-                  });
-              </script>
-            </div>
+          </div>
+          <div id="unity-warning"></div>
+          <div id="unity-footer">
+            <div id="unity-fullscreen-button"></div>
+            <div id="unity-mobile-warning">Best experienced in landscape orientation on mobile.</div>
           </div>
         </div>
       </div>
-      <p class="text-center text-muted small">
-        Having trouble loading the build? Try refreshing the page or clearing your browser cache. Unity WebGL builds can take
-        a moment to compile on first load.
-      </p>
     </div>
+  </div>
+  <div class="container-xl">
+    <script src="<%= @chronocrow_loader_path %>"></script>
+    <script>
+      const canvas = document.querySelector('#unity-canvas');
+      const container = document.querySelector('#unity-container');
+      const layout = document.querySelector('.chrono-crow-layout');
+      const frame = document.querySelector('.chrono-crow-player-frame');
+      const loadingBar = document.querySelector('#unity-loading-bar');
+      const progressBarFull = document.querySelector('#unity-progress-bar-full');
+      const fullscreenButton = document.querySelector('#unity-fullscreen-button');
+      const warningBanner = document.querySelector('#unity-warning');
+      warningBanner.style.display = 'none';
+
+      function updateBannerVisibility() {
+        warningBanner.style.display = warningBanner.children.length ? 'block' : 'none';
+      }
+
+      function unityShowBanner(msg, type) {
+        const div = document.createElement('div');
+        div.innerHTML = msg;
+        div.className = 'unity-banner ' + (type || '');
+        warningBanner.appendChild(div);
+        if (type === 'warning') {
+          setTimeout(() => {
+            warningBanner.removeChild(div);
+            updateBannerVisibility();
+          }, 5000);
+        } else if (type === 'error') {
+          div.addEventListener('click', () => {
+            warningBanner.removeChild(div);
+            updateBannerVisibility();
+          });
+        }
+        updateBannerVisibility();
+      }
+
+      const config = {
+        dataUrl: "<%= @chronocrow_data_path %>",
+        frameworkUrl: "<%= @chronocrow_framework_path %>",
+        codeUrl: "<%= @chronocrow_wasm_path %>",
+        streamingAssetsUrl: "<%= @chronocrow_streaming_assets_path %>",
+        companyName: 'Chrono Crow Team',
+        productName: 'Chrono Crow',
+        productVersion: '0.1',
+        showBanner: unityShowBanner
+      };
+
+      const aspectRatio = 16 / 9;
+
+      function applyResponsiveSizing() {
+        const viewportWidth = window.innerWidth;
+        const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) || viewportWidth < 992;
+        const maxWidth = 1920;
+        const availableWidth = Math.min(layout.clientWidth, viewportWidth);
+
+        const targetWidth = Math.min(availableWidth, maxWidth);
+
+        if (isMobile) {
+          container.classList.remove('unity-desktop');
+          container.classList.add('unity-mobile');
+          frame.style.width = targetWidth + 'px';
+          canvas.style.maxWidth = '100%';
+          canvas.style.maxHeight = '100vh';
+          canvas.width = targetWidth;
+          canvas.height = Math.round(targetWidth / aspectRatio);
+          config.devicePixelRatio = 1;
+        } else {
+          container.classList.add('unity-desktop');
+          container.classList.remove('unity-mobile');
+          frame.style.width = targetWidth + 'px';
+          canvas.style.maxWidth = '100%';
+          canvas.style.maxHeight = '';
+          canvas.width = maxWidth;
+          canvas.height = Math.round(maxWidth / aspectRatio);
+          config.devicePixelRatio = window.devicePixelRatio || 1;
+        }
+      }
+
+      applyResponsiveSizing();
+      window.addEventListener('resize', applyResponsiveSizing);
+
+      loadingBar.style.display = 'block';
+
+      createUnityInstance(canvas, config, (progress) => {
+        progressBarFull.style.width = 100 * progress + '%';
+      })
+        .then((unityInstance) => {
+          loadingBar.style.display = 'none';
+          fullscreenButton.onclick = () => {
+            unityInstance.SetFullscreen(1);
+          };
+        })
+        .catch((message) => {
+          unityShowBanner(message, 'error');
+        });
+    </script>
+    <p class="text-center text-muted small mt-4">
+      Having trouble loading the build? Try refreshing the page or clearing your browser cache. Unity WebGL builds can take
+      a moment to compile on first load.
+    </p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- remove the card wrapper and reorganize the Chrono Crow page so the Unity canvas can expand to the full 1920×1080 footprint while keeping the how-to-play panel accessible
- add responsive sizing logic for the Unity canvas so it scales down gracefully on smaller viewports and prompts mobile players to rotate for a better fit
- introduce dedicated styling for the page background, info panel, and player frame to present a polished layout without enclosing the game in a card

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0f5e10e24832a838adfd803c6177f