### PR TITLE
Expand filter-dependent visibility to entire page

### DIFF
--- a/app/javascript/filter_projects.js
+++ b/app/javascript/filter_projects.js
@@ -13,7 +13,7 @@ function filterProjects(category, element) {
 
   var projects = projectsSection.querySelectorAll('.project-card');
   var buttons = filterButtons ? filterButtons.querySelectorAll('.btn') : [];
-  var filterDependents = projectsSection.querySelectorAll('.filter-dependent');
+  var filterDependents = document.querySelectorAll('.filter-dependent');
   var hasVisibleProject = false;
 
   buttons.forEach(function(btn) {
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', function() {
     project.classList.add('project-hidden');
   });
 
-  var filterDependents = projectsSection.querySelectorAll('.filter-dependent');
+  var filterDependents = document.querySelectorAll('.filter-dependent');
   filterDependents.forEach(function(element) {
     element.classList.add('project-hidden');
   });


### PR DESCRIPTION
## Summary
- query all filter-dependent sections when filtering projects so non-project sections respond to filters
- hide every filter-dependent element on initial load and rely on filter selection to reveal them

## Testing
- not run (Ruby 3.2.3 present while app requires 3.1.2)


------
https://chatgpt.com/codex/tasks/task_e_68d10892759c832a96b49e7bd7f96ab1