### PR TITLE
Enhance project filter buttons styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -147,6 +147,48 @@ a:hover {
 }
 
 
+.filter-buttons .btn {
+  padding: 0.85rem 1.9rem;
+  font-size: 1.1rem;
+  border-radius: 3rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  box-shadow: 0 1rem 2rem rgba(0, 105, 217, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-buttons .btn:hover,
+.filter-buttons .btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 1.2rem 2.4rem rgba(0, 105, 217, 0.35);
+  outline: none;
+}
+
+.filter-buttons .btn:focus-visible {
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
+}
+
+.filter-buttons .btn .filter-label {
+  white-space: nowrap;
+}
+
+@media (max-width: 576px) {
+  .filter-buttons .btn {
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 0.75rem;
+    font-size: 1rem;
+    padding: 0.75rem 1.5rem;
+  }
+
+  .filter-buttons .btn:last-child {
+    margin-bottom: 0;
+  }
+}
+
+
 .bg-col {
   background-color: #F8F9FA;
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -29,11 +29,13 @@
         <h3 class="text-center filter-dependent">Featured Projects</h3>
         <!-- Filter Buttons -->
         <div class="filter-buttons text-center">
-          <button onclick="filterProjects('web', this)" class="btn btn-primary mx-1" aria-label="Show web projects">
-            <i class="fas fa-code"></i>
+          <button onclick="filterProjects('web', this)" class="btn btn-primary btn-lg mx-1" aria-label="Show web projects">
+            <i class="fas fa-code" aria-hidden="true"></i>
+            <span class="filter-label">Web Projects</span>
           </button>
-          <button onclick="filterProjects('game', this)" class="btn btn-primary mx-1" aria-label="Show game projects">
-            <i class="fas fa-gamepad"></i>
+          <button onclick="filterProjects('game', this)" class="btn btn-primary btn-lg mx-1" aria-label="Show game projects">
+            <i class="fas fa-gamepad" aria-hidden="true"></i>
+            <span class="filter-label">Game Projects</span>
           </button>
         </div>
         <p class="text-center text-muted mt-3" id="project-filter-message">


### PR DESCRIPTION
## Summary
- add descriptive labels and larger sizing to the project filter buttons so they read as primary controls
- increase padding, typography, border radius, and prominence of the filter buttons with responsive tweaks for mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d10895f9c8832a925f42af102dc97f