### PR TITLE
Ensure project sections hidden by default

### DIFF
--- a/app/javascript/filter_projects.js
+++ b/app/javascript/filter_projects.js
@@ -59,31 +59,3 @@ function filterProjects(category, element) {
 
 // Make the function globally accessible
 window.filterProjects = filterProjects;
-
-document.addEventListener('DOMContentLoaded', function() {
-  var filterButtons = document.querySelector('.filter-buttons');
-  var message = document.getElementById('project-filter-message');
-  if (!filterButtons && !message) {
-    return;
-  }
-
-  var projectsSection = document.querySelector('#projects');
-  if (!projectsSection) {
-    return;
-  }
-
-  var projects = projectsSection.querySelectorAll('.project-card');
-  projects.forEach(function(project) {
-    project.classList.add('project-hidden');
-  });
-
-  var filterDependents = document.querySelectorAll('.filter-dependent');
-  filterDependents.forEach(function(element) {
-    element.classList.add('project-hidden');
-  });
-
-  if (message) {
-    message.style.display = '';
-    message.textContent = 'Select Web or Game to explore featured work.';
-  }
-});

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -26,7 +26,7 @@
     <!-- Featured Projects Section -->
     <section id="projects" class="container mt-5">
       <div data-aos="fade-up" data-aos-duration="500" data-aos-delay="50" data-aos-easing="ease-in-out">
-        <h3 class="text-center filter-dependent">Featured Projects</h3>
+        <h3 class="text-center filter-dependent project-hidden">Featured Projects</h3>
         <!-- Filter Buttons -->
         <div class="filter-buttons text-center">
           <button onclick="filterProjects('web', this)" class="btn btn-primary btn-lg mx-1" aria-label="Show web projects">
@@ -41,7 +41,7 @@
         <p class="text-center text-muted mt-3" id="project-filter-message">
           Select Web or Game to explore featured work.
         </p>
-        <div class="row justify-content-center filter-dependent">
+        <div class="row justify-content-center filter-dependent project-hidden">
           <!-- Raspberry Pi Server Card -->
           <div class="col-md-4 mt-3 web project-card d-flex">
             <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
@@ -291,7 +291,7 @@
           </div>
         </section>
         <!-- Smaller Fun Projects Section -->
-<section id="smaller-projects" class="container mt-5 filter-dependent">
+<section id="smaller-projects" class="container mt-5 filter-dependent project-hidden">
   <h3 class="text-center">Smaller Fun Projects</h3>
   <!--
     Use align-items-stretch on the row to ensure columns (and thus cards)
@@ -372,7 +372,7 @@
 </section>
 
         <!-- Contact -->
-        <section id="contact" class="container my-5 pb-5 text-center filter-dependent">
+        <section id="contact" class="container my-5 pb-5 text-center filter-dependent project-hidden">
           <div class="mb-5">
             <h3>Contact Me</h3>
             <div class="d-flex justify-content-center">


### PR DESCRIPTION
## Summary
- add the project-hidden class to featured and dependent sections so they start hidden before filtering
- remove the redundant DOMContentLoaded handler from filter_projects.js now that the markup sets the initial state

## Testing
- bin/rails test *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d11360a824832a8449e7c4dd2e36c6