### PR TITLE
Refine project card media styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,25 @@
 
 @import "bootstrap";
 
+.project-card__media {
+  /*
+   * Adjust `--project-card-media-ratio` to update the shared media aspect ratio
+   * across every featured project card in one place.
+   */
+  --project-card-media-ratio: 4 / 5;
+  position: relative;
+  width: 100%;
+  aspect-ratio: var(--project-card-media-ratio);
+  overflow: hidden;
+}
+
+.project-card__media img,
+.project-card__media-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .project-hidden {
   display: none !important;
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -49,11 +49,11 @@
           <div class="col-md-4 mt-3 web project-card d-flex">
             <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
               <!-- Image Container -->
-              <div style="height: 500px; overflow: hidden;">
+              <div class="project-card__media">
                 <img
               src="<%= asset_path 'raspberry-pi-server.jpg' %>"
               alt="Raspberry Pi Server Screenshot"
-              style="width: 100%; height: 100%; object-fit: cover;"
+              class="project-card__media-image"
             />
           </div>
           <!-- Card Body -->
@@ -79,11 +79,11 @@
       <!-- CelebrantGPT Card -->
       <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-          <div style="height: 500px; overflow: hidden;">
+          <div class="project-card__media">
             <img
               src="<%= asset_path 'celebrantgpt_screenshot.jpg' %>"
               alt="CelebrantGPT Screenshot"
-              style="width: 100%; height: 100%; object-fit: cover;"
+              class="project-card__media-image"
             />
           </div>
           <div class="card-body d-flex flex-column">
@@ -109,11 +109,11 @@
       <!-- ChoreQuest Card -->
       <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-          <div style="height: 500px; overflow: hidden;">
+          <div class="project-card__media">
             <img
               src="<%= asset_path 'chorequest_screenshot.webp' %>"
               alt="ChoreQuest Screenshot"
-              style="width: 100%; height: 100%; object-fit: cover;"
+              class="project-card__media-image"
             />
           </div>
           <div class="card-body d-flex flex-column">
@@ -138,11 +138,11 @@
       <!-- Three.js Portfolio Card -->
       <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-          <div style="height: 500px; overflow: hidden;">
+          <div class="project-card__media">
             <img
               src="<%= asset_path 'threejs_portfolio_screenshot.webp' %>"
               alt="Three.js Portfolio Screenshot"
-              style="width: 100%; height: 100%; object-fit: cover;"
+              class="project-card__media-image"
             />
           </div>
           <div class="card-body d-flex flex-column">
@@ -166,11 +166,11 @@
       <!-- FigMax Card -->
       <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-          <div style="height: 500px; overflow: hidden;">
+          <div class="project-card__media">
             <img
               src="<%= asset_path 'FigMax (1).webp' %>"
               alt="FigMax Screenshot"
-              style="width: 100%; height: 100%; object-fit: cover;"
+              class="project-card__media-image"
             />
           </div>
           <div class="card-body d-flex flex-column">
@@ -196,11 +196,11 @@
       <!-- Word Quest Card -->
       <div class="col-md-4 mt-3 web project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-          <div style="height: 500px; overflow: hidden;">
+          <div class="project-card__media">
             <img
               src="<%= asset_path 'wordquest_screenshot.webp' %>"
               alt="Word Quest Screenshot"
-              style="width: 100%; height: 100%; object-fit: cover;"
+              class="project-card__media-image"
             />
           </div>
           <div class="card-body d-flex flex-column">
@@ -219,8 +219,8 @@
       <!-- ChronoCrow Card -->
       <div class="col-md-4 mt-3 game project-card d-flex">
         <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-          <div style="height: 500px; overflow: hidden;">
-            <%= image_tag 'ChronoCrow.png', alt: 'ChronoCrow key art', style: 'width: 100%; height: 100%; object-fit: cover;' %>
+          <div class="project-card__media">
+            <%= image_tag 'ChronoCrow.png', alt: 'ChronoCrow key art', class: 'project-card__media-image' %>
           </div>
           <div class="card-body d-flex flex-column">
             <h3 class="card-title text-center">ChronoCrow</h3>
@@ -236,11 +236,11 @@
         <!-- Time Tracker Card -->
         <div class="col-md-4 mt-3 web project-card d-flex">
           <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-            <div style="height: 500px; overflow: hidden;">
+            <div class="project-card__media">
               <img
                 src="<%= asset_path 'timetracker logo.png' %>"
                 alt="Time Tracker Logo"
-                style="width: 100%; height: 100%; object-fit: cover;"
+                class="project-card__media-image"
               />
             </div>
             <div class="card-body d-flex flex-column">
@@ -262,11 +262,11 @@
         <!-- Stumped Album Card -->
             <div class="col-md-4 mt-3 web project-card d-flex">
               <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
-                <div style="height: 500px; overflow: hidden;">
+                <div class="project-card__media">
                   <img
               src="<%= asset_path 'StumpedAlbumCover.webp' %>"
                     alt="Stumped Album Cover"
-                    style="width: 100%; height: 100%; object-fit: cover;"
+                    class="project-card__media-image"
                     />
                   </div>
                   <div class="card-body d-flex flex-column">


### PR DESCRIPTION
## Summary
- add a reusable project card media helper with an adjustable custom property for consistent card imagery
- replace inline media styling on the home page's featured project cards with the new helper classes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d11d4960d4832abd76428be810558e