### PR TITLE
Fix project card image sizing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,20 @@
   aspect-ratio: var(--project-card-compact-aspect-ratio);
 }
 
+.project-card__media {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  max-height: 14rem;
+  overflow: hidden;
+}
+
+.project-card__media-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
  body {
   font-family: Arial, sans-serif;
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- enforce a consistent 16:9 frame for project card media containers
- ensure images scale to fill the reserved card artwork space without distortion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d11eefbcb8832a99f17d7ad78c96b1