### PR TITLE
Add Emirates Skywards game case study

### DIFF
--- a/app/assets/images/emirates-skywards-booth-1.svg
+++ b/app/assets/images/emirates-skywards-booth-1.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000">
+  <defs>
+    <linearGradient id="bg1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f1d33" />
+      <stop offset="100%" stop-color="#1b2f52" />
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f3f0ff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#c5d8ff" stop-opacity="0.35" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1000" fill="url(#bg1)" />
+  <g opacity="0.5">
+    <circle cx="400" cy="220" r="150" fill="url(#glow)" />
+    <circle cx="1200" cy="180" r="180" fill="url(#glow)" />
+    <circle cx="900" cy="760" r="200" fill="url(#glow)" />
+  </g>
+  <g fill="#ffffff" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif">
+    <text x="180" y="200" font-size="54" font-weight="600">25 Year Anniversary Booth</text>
+    <text x="180" y="270" font-size="32" opacity="0.85">Immersive Unity stations for Emirates Skywards members</text>
+  </g>
+  <g transform="translate(160,340)">
+    <rect x="0" y="0" width="580" height="420" rx="28" fill="#121c30" stroke="#cfd7f6" stroke-width="6" />
+    <text x="290" y="100" font-size="42" fill="#f4f6ff" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Attract Mode</text>
+    <text x="290" y="170" font-size="26" fill="#d3dcff" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Animated loop draws in travellers</text>
+    <text x="290" y="230" font-size="26" fill="#d3dcff" text-anchor="middle" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif">Tablet-friendly layout</text>
+    <text x="290" y="300" font-size="26" fill="#d3dcff" text-anchor="middle" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif">PlayFab login integration</text>
+  </g>
+  <g transform="translate(860,320)">
+    <rect x="0" y="0" width="580" height="460" rx="28" fill="#14213b" stroke="#f6c746" stroke-width="6" opacity="0.95" />
+    <text x="290" y="110" font-size="44" fill="#fff4d9" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Three Mini-Games</text>
+    <text x="290" y="190" font-size="28" fill="#fff4d9" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Pilot Runner • Hat Swap • Spin the Wheel</text>
+    <text x="290" y="260" font-size="26" fill="#ffe9aa" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Collect Skywards tokens and unlock tiers</text>
+    <text x="290" y="330" font-size="26" fill="#ffe9aa" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Dynamic UI, audio, and animation polish</text>
+    <text x="290" y="400" font-size="26" fill="#ffe9aa" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Built for live events</text>
+  </g>
+</svg>

--- a/app/assets/images/emirates-skywards-booth-2.svg
+++ b/app/assets/images/emirates-skywards-booth-2.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000">
+  <defs>
+    <radialGradient id="bg2" cx="0.5" cy="0.4" r="0.9">
+      <stop offset="0%" stop-color="#1d2f4d" />
+      <stop offset="100%" stop-color="#0c1528" />
+    </radialGradient>
+    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f7dba7" />
+      <stop offset="100%" stop-color="#f4b942" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1000" fill="url(#bg2)" />
+  <g stroke="#ffffff" stroke-opacity="0.2" stroke-width="2">
+    <path d="M0 140 L1600 140" />
+    <path d="M0 320 L1600 320" />
+    <path d="M0 720 L1600 720" />
+    <path d="M180 0 L180 1000" />
+    <path d="M800 0 L800 1000" />
+    <path d="M1420 0 L1420 1000" />
+  </g>
+  <g font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" fill="#ffffff">
+    <text x="800" y="140" font-size="60" text-anchor="middle" font-weight="600">Emirates Skywards Unity Game Suite</text>
+    <text x="800" y="210" font-size="34" text-anchor="middle" fill="#dfe8ff">Event-ready gameplay built with PlayFab integration</text>
+  </g>
+  <g transform="translate(220,340)">
+    <rect x="0" y="0" width="520" height="420" rx="26" fill="#18243c" opacity="0.9" />
+    <text x="260" y="90" font-size="36" fill="#f8e5b0" font-weight="600" text-anchor="middle">Tiered Quiz Stage</text>
+    <text x="260" y="160" font-size="24" fill="#f7f0d2" text-anchor="middle">Questions adapt to tokens collected in-game.</text>
+    <text x="260" y="220" font-size="24" fill="#f7f0d2" text-anchor="middle">Supports Bronze, Silver, Gold, and Platinum paths.</text>
+    <text x="260" y="280" font-size="24" fill="#f7f0d2" text-anchor="middle">Customizable via companion editor.</text>
+  </g>
+  <g transform="translate(900,340)">
+    <rect x="0" y="0" width="480" height="420" rx="26" fill="#172033" opacity="0.9" />
+    <text x="240" y="90" font-size="36" fill="#f8e5b0" font-weight="600" text-anchor="middle">Companion App</text>
+    <text x="240" y="160" font-size="24" fill="#f7f0d2" text-anchor="middle">Unity tool for Emirates staff to update quiz content</text>
+    <text x="240" y="220" font-size="24" fill="#f7f0d2" text-anchor="middle">Real-time PlayFab syncing keeps booths up to date</text>
+    <text x="240" y="280" font-size="24" fill="#f7f0d2" text-anchor="middle">Empowers non-technical teams at events</text>
+  </g>
+  <g>
+    <rect x="480" y="820" width="640" height="18" fill="url(#accent2)" />
+    <text x="800" y="880" font-size="30" fill="#fefefe" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" text-anchor="middle">Attract Screen • Gameplay Stations • Quiz Finale • Companion Editor</text>
+  </g>
+</svg>

--- a/app/assets/images/emirates-skywards-card.svg
+++ b/app/assets/images/emirates-skywards-card.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#152238" />
+      <stop offset="100%" stop-color="#27405f" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f7d78c" />
+      <stop offset="100%" stop-color="#d6af3a" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="25" flood-color="#000" flood-opacity="0.35" />
+    </filter>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" />
+  <g filter="url(#shadow)">
+    <rect x="100" y="140" width="1000" height="520" rx="28" fill="#1f2f4a" opacity="0.65" />
+  </g>
+  <g>
+    <text x="600" y="320" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" font-size="80" font-weight="600" fill="#ffffff" text-anchor="middle">Emirates Skywards</text>
+    <text x="600" y="400" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" font-size="38" fill="#d7e6ff" text-anchor="middle">Unity Game Suite Experience</text>
+  </g>
+  <g>
+    <path d="M220 520 L980 520" stroke="url(#accent)" stroke-width="14" stroke-linecap="round" opacity="0.85" />
+    <text x="600" y="590" font-family="'Poppins', 'Helvetica', 'Arial', sans-serif" font-size="32" fill="#f7f9ff" text-anchor="middle">Runner • Hat Swap • Spin the Wheel • Tiered Quiz</text>
+  </g>
+</svg>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -198,6 +198,42 @@ a:hover {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.emirates-page {
+  background: linear-gradient(135deg, #0f1a2d 0%, #162544 60%, #1e3358 100%);
+  color: #f5f7ff;
+}
+
+.emirates-page .display-4 {
+  color: #f8fbff;
+  font-weight: 600;
+}
+
+.emirates-page p {
+  color: rgba(243, 247, 255, 0.8);
+}
+
+.emirates-page .image-card {
+  background: rgba(17, 29, 51, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.emirates-page .feature-card {
+  background: rgba(12, 22, 41, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 1.5rem 3rem rgba(6, 15, 30, 0.35);
+  color: #f5f7ff;
+}
+
+.emirates-page .feature-card h2 {
+  color: #f8d377;
+}
+
+.emirates-page .feature-card p {
+  color: rgba(231, 238, 255, 0.85);
+}
+
 .filter-buttons .btn:hover,
 .filter-buttons .btn:focus {
   transform: translateY(-2px);

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,4 +25,7 @@ class PagesController < ApplicationController
     @chronocrow_wasm_path = File.join(@chronocrow_root_path, 'Build', "#{build_basename}.wasm")
     @chronocrow_streaming_assets_path = File.join(@chronocrow_root_path, 'StreamingAssets')
   end
+
+  def emirates_skywards
+  end
 end

--- a/app/views/pages/emirates_skywards.html.erb
+++ b/app/views/pages/emirates_skywards.html.erb
@@ -1,0 +1,58 @@
+<div class="emirates-page py-5">
+  <div class="container">
+    <div class="row align-items-center mb-5">
+      <div class="col-12 col-lg-6" data-aos="fade-right" data-aos-duration="600">
+        <h1 class="display-4 mb-3">Emirates Skywards Unity Game Suite</h1>
+        <p class="lead text-muted mb-4">
+          Developed a branded Unity game experience for Emirates Skywards, designed for use at promotional events on tablet devices.
+          The suite features three interactive mini-games — a Runner where players pilot a plane through obstacles, a Hat Swap memory game,
+          and a Spin the Wheel token game. Each session culminates in a tiered quiz stage, with questions tailored to the tokens collected.
+          Built with Unity and PlayFab integration, the project included attract and login screens, dynamic UI flows, sound design,
+          animation, and gameplay scripting.
+        </p>
+        <p class="text-muted">
+          Alongside the booth game, created a standalone Unity companion app that enables Emirates staff to easily update and manage quiz
+          questions in real time through PlayFab. This tool streamlined client control over content without requiring developer intervention,
+          ensuring flexibility for events and future updates.
+        </p>
+      </div>
+      <div class="col-12 col-lg-6" data-aos="fade-left" data-aos-duration="600">
+        <div class="image-card shadow-lg rounded overflow-hidden mb-4">
+          <%= image_tag 'emirates-skywards-booth-1.svg', class: 'img-fluid w-100', alt: 'Emirates Skywards booth illustration highlighting mini-games' %>
+        </div>
+        <div class="image-card shadow-lg rounded overflow-hidden">
+          <%= image_tag 'emirates-skywards-booth-2.svg', class: 'img-fluid w-100', alt: 'Emirates Skywards Unity Game Suite companion app overview' %>
+        </div>
+      </div>
+    </div>
+    <div class="row g-4 mt-2">
+      <div class="col-12 col-lg-4">
+        <div class="feature-card h-100 p-4 shadow-sm">
+          <h2 class="h4 mb-3">Event-first UX</h2>
+          <p class="mb-0 text-muted">
+            Designed for high-traffic airport activations with attract screens, fast session resets, and tablet-optimized inputs that keep
+            lines moving and guests engaged.
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-lg-4">
+        <div class="feature-card h-100 p-4 shadow-sm">
+          <h2 class="h4 mb-3">PlayFab Integration</h2>
+          <p class="mb-0 text-muted">
+            Both the booth and the quiz editor companion app connect to PlayFab, ensuring synchronized progress, token rewards, and
+            live updates to quiz content without redeployments.
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-lg-4">
+        <div class="feature-card h-100 p-4 shadow-sm">
+          <h2 class="h4 mb-3">Immersive Polish</h2>
+          <p class="mb-0 text-muted">
+            Custom sound design, animation, and cohesive branding align with Emirates Skywards visuals, delivering a premium interactive
+            moment for travellers exploring loyalty tiers.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -258,6 +258,23 @@
           </div>
         </div>
       </div>
+      <!-- Emirates Skywards Unity Game Suite Card -->
+      <div class="col-md-4 mt-3 game project-card d-flex">
+        <div class="card mb-4 shadow-sm h-100 d-flex flex-column">
+          <div class="project-card__media">
+            <%= image_tag 'emirates-skywards-card.svg', alt: 'Emirates Skywards Unity Game Suite card art', class: 'project-card__media-image' %>
+          </div>
+          <div class="card-body d-flex flex-column">
+            <h3 class="card-title text-center">Emirates Skywards</h3>
+            <p class="card-text flex-grow-1 darker-p">
+              Unity-powered trio of mini-games with a tiered quiz finale, built for Emirates Skywards promotional activations.
+            </p>
+            <div class="text-center mt-auto">
+              <%= link_to 'View Skywards Case Study', emirates_skywards_path, class: 'btn btn-primary' %>
+            </div>
+          </div>
+        </div>
+      </div>
         <!-- Time Tracker Card -->
         <div class="col-md-4 mt-3 web project-card d-flex">
           <div class="card mb-4 shadow-sm h-100 d-flex flex-column">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get 'pages/home'
   get 'pages/secrets'
   get 'chronocrow', to: 'pages#chrono_crow', as: :chrono_crow
+  get 'emirates-skywards', to: 'pages#emirates_skywards', as: :emirates_skywards
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Summary
- add an Emirates Skywards Unity Game Suite card to the home page game projects
- create a dedicated Emirates Skywards case study page with descriptive copy and supporting artwork
- style the new page with gradients and glassmorphism cues that align with the home page aesthetic

## Testing
- ⚠️ `bin/rails routes -c pages` *(fails: Ruby 3.2.3 present, but Gemfile requires 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbb052744832a8fcfe010dc422703