### PR TITLE
Update Emirates Skywards page typography

### DIFF
--- a/app/views/pages/emirates_skywards.html.erb
+++ b/app/views/pages/emirates_skywards.html.erb
@@ -3,14 +3,14 @@
     <div class="row align-items-center mb-5">
       <div class="col-12 col-lg-6" data-aos="fade-right" data-aos-duration="600">
         <h1 class="display-4 mb-3">Emirates Skywards Unity Game Suite</h1>
-        <p class="lead text-muted mb-4">
+        <p class="lead mb-4">
           Developed a branded Unity game experience for Emirates Skywards, designed for use at promotional events on tablet devices.
           The suite features three interactive mini-games — a Runner where players pilot a plane through obstacles, a Hat Swap memory game,
           and a Spin the Wheel token game. Each session culminates in a tiered quiz stage, with questions tailored to the tokens collected.
           Built with Unity and PlayFab integration, the project included attract and login screens, dynamic UI flows, sound design,
           animation, and gameplay scripting.
         </p>
-        <p class="text-muted">
+        <p>
           Alongside the booth game, created a standalone Unity companion app that enables Emirates staff to easily update and manage quiz
           questions in real time through PlayFab. This tool streamlined client control over content without requiring developer intervention,
           ensuring flexibility for events and future updates.
@@ -29,7 +29,7 @@
       <div class="col-12 col-lg-4">
         <div class="feature-card h-100 p-4 shadow-sm">
           <h2 class="h4 mb-3">Event-first UX</h2>
-          <p class="mb-0 text-muted">
+          <p class="mb-0">
             Designed for high-traffic airport activations with attract screens, fast session resets, and tablet-optimized inputs that keep
             lines moving and guests engaged.
           </p>
@@ -38,7 +38,7 @@
       <div class="col-12 col-lg-4">
         <div class="feature-card h-100 p-4 shadow-sm">
           <h2 class="h4 mb-3">PlayFab Integration</h2>
-          <p class="mb-0 text-muted">
+          <p class="mb-0">
             Both the booth and the quiz editor companion app connect to PlayFab, ensuring synchronized progress, token rewards, and
             live updates to quiz content without redeployments.
           </p>
@@ -47,7 +47,7 @@
       <div class="col-12 col-lg-4">
         <div class="feature-card h-100 p-4 shadow-sm">
           <h2 class="h4 mb-3">Immersive Polish</h2>
-          <p class="mb-0 text-muted">
+          <p class="mb-0">
             Custom sound design, animation, and cohesive branding align with Emirates Skywards visuals, delivering a premium interactive
             moment for travellers exploring loyalty tiers.
           </p>


### PR DESCRIPTION
## Summary
- remove Bootstrap muted text classes from the Emirates Skywards page so content inherits the light typography defined for the page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddbe83ffe0832aab4113cf223d84ad