### PR TITLE
Update Popper pin to CDN package

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,7 +6,7 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 
-pin "popper", to: 'popper.js', preload: true
+pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/esm/index.js", preload: true
 pin "bootstrap", to: 'bootstrap.min.js', preload: true
 pin "letter_select", to: "letter_select.js"
 pin "particles.min", to: "particles.min.js"


### PR DESCRIPTION
## Summary
- point the Popper importmap entry to the CDN-distributed @popperjs/core package
- remove the obsolete local Popper pin that is no longer needed

## Testing
- ./bin/importmap json *(fails: Ruby 3.2.3 is installed but the Gemfile requires 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc49c4cb8832aa058edfe3c6fd1fb