### PR TITLE
Use importmap for layout javascript

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,10 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <!-- Include your CSS (Bootstrap, custom styles, etc.) -->
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
-    <script type="module" src="<%= asset_path('letter_select.js') %>"></script>
-    <script type="module" src="<%= asset_path('dark_mode_toggle.js') %>"></script>
-    <script type="module" src="<%= asset_path('filter_projects.js') %>"></script>
+    <%= javascript_importmap_tags %>
     <script src="https://cdn.jsdelivr.net/npm/aos@2.3.1/dist/aos.js"></script>
     <script src="https://w.soundcloud.com/player/api.js"></script> <!-- SoundCloud API -->
   </head>


### PR DESCRIPTION
## Summary
- replace the layout's javascript include tag with the Rails importmap helper
- remove redundant manual module script tags now handled by application.js

## Testing
- bin/rails server -b 0.0.0.0 -p 3000 *(fails: Ruby 3.2.3 detected but Gemfile requires 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc4917800832aae5152b2b4260d71