### PR TITLE
Add Turbo reload tracking to application stylesheet tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <!-- Include your CSS (Bootstrap, custom styles, etc.) -->
-    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <script src="https://cdn.jsdelivr.net/npm/aos@2.3.1/dist/aos.js"></script>
     <script src="https://w.soundcloud.com/player/api.js"></script> <!-- SoundCloud API -->


### PR DESCRIPTION
## Summary
- add the data-turbo-track reload attribute to the application stylesheet link so Turbo notices CSS updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc6cceee8832a96a85ac86be3f04c