### PR TITLE
Add missing importmap pins for frontend modules

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,3 +10,5 @@ pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/di
 pin "bootstrap", to: 'bootstrap.min.js', preload: true
 pin "letter_select", to: "letter_select.js"
 pin "particles.min", to: "particles.min.js"
+pin "dark_mode_toggle", to: "dark_mode_toggle.js"
+pin "filter_projects", to: "filter_projects.js"


### PR DESCRIPTION
## Summary
- add explicit importmap pins for dark_mode_toggle and filter_projects modules
- ensure Popper remains pinned via @popperjs/core after attempting to update via helper script

## Testing
- not run (ruby version mismatch prevents executing Rails binstubs)

------
https://chatgpt.com/codex/tasks/task_e_68ddc6cf5da8832a9055cf7b5d9c205a