### PR TITLE
Fix broken project filter buttons

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,7 +4,6 @@ import "@hotwired/turbo-rails"
 import "controllers"
 
 import "bootstrap"
-import "../stylesheets/application"
 import "@popperjs/core"
 
 import "letter_select"  // Assuming this is in your importmap or located correctly in the asset pipeline.


### PR DESCRIPTION
## Summary
- remove an invalid stylesheet import from the JavaScript entrypoint so the module loads without errors
- allow the filterProjects helper to be registered on window again, restoring the Web/Game buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddd39388d8832abb9f59b069709f2a