### PR TITLE
Remove redundant CV modal footer button

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -477,9 +477,6 @@
                   </a>
                 </div>
               </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the extra footer close button from the CV selection modal so only the header close control remains

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd9087584832aa9bab1b0bfdcf6a7