### PR TITLE
Update navbar anchor links to home and contact

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,16 +1,13 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
-    <a class="navbar-brand" href="#">My Portfolio</a>
+    <a class="navbar-brand" href="#home">My Portfolio</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto"> <!-- Changed ml-auto to ms-auto for Bootstrap 5 -->
         <li class="nav-item">
-          <a class="nav-link" aria-current="page" href="/">Home</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#projects">Projects</a>
+          <a class="nav-link" aria-current="page" href="#home">Home</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="#contact">Contact</a>


### PR DESCRIPTION
## Summary
- point the navbar brand link at the home section anchor
- limit the navigation menu to Home and Contact anchor links to match the new structure

## Testing
- bin/rails server -b 0.0.0.0 -p 3000 *(fails: Ruby version mismatch with Gemfile specification)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd91ccf18832aa872e945bb7c5e82