### PR TITLE
Ensure Popper loads before Bootstrap

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,8 +3,8 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 
-import "bootstrap"
 import "@popperjs/core"
+import "bootstrap"
 
 import "letter_select"  // Assuming this is in your importmap or located correctly in the asset pipeline.
 import "dark_mode_toggle";


### PR DESCRIPTION
## Summary
- reorder the JavaScript imports so Popper loads before Bootstrap to satisfy Bootstrap's dependency

## Testing
- ⚠️ `bin/rails server -b 0.0.0.0 -p 3000` *(fails: Ruby 3.2.3, Gemfile requires 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd9247db4832a91acbd3602e92b95