### PR TITLE
Ensure AOS reinitializes after Turbo navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,21 @@
       <%= yield %>
     </div>
     <script>
-      document.addEventListener('DOMContentLoaded', function() {
-          AOS.init(); // Initialize AOS after DOM is fully loaded
-      });
+      (function() {
+        const initAOS = function() {
+          if (typeof AOS === 'undefined') return;
+
+          if (!window.__aosInitialized) {
+            AOS.init();
+            window.__aosInitialized = true;
+          } else if (typeof AOS.refreshHard === 'function') {
+            AOS.refreshHard();
+          }
+        };
+
+        document.addEventListener('DOMContentLoaded', initAOS);
+        document.addEventListener('turbo:load', initAOS);
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- initialize AOS via a shared handler to support both DOMContentLoaded and turbo:load events
- guard against duplicate initialization and trigger a hard refresh when navigating with Turbo

## Testing
- `bin/rails server -b 0.0.0.0 -p 3000` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_68dddff346e4832ab5cde62b6c944801