### PR TITLE
Refine dark mode toggle initialization lifecycle

### DIFF
--- a/app/javascript/dark_mode_toggle.js
+++ b/app/javascript/dark_mode_toggle.js
@@ -1,45 +1,46 @@
-const toggleButton = document.getElementById('dark-mode-toggle');
+function initializeDarkModeToggle() {
+  const toggleButton = document.getElementById('dark-mode-toggle');
 
-if (!toggleButton) return;
+  if (!toggleButton) return;
+  if (toggleButton.dataset.darkModeInitialized === 'true') return;
 
-toggleButton.addEventListener('click', function () {
-  // Toggle dark mode class on the body
-  document.body.classList.toggle('dark-mode');
+  toggleButton.dataset.darkModeInitialized = 'true';
 
-  // Get image elements
-  const darkImage = document.getElementById('dark-image');
-  const lightImage = document.getElementById('light-image');
-  const navbar = document.querySelector('.navbar');
-  const contact = document.querySelectorAll('.contact')
+  toggleButton.addEventListener('click', function () {
+    document.body.classList.toggle('dark-mode');
 
-  // Check if dark mode is active
-  if (document.body.classList.contains('dark-mode')) {
-    // Show dark image, hide light image
-    if (darkImage) darkImage.style.display = 'block';
-    if (lightImage) lightImage.style.display = 'none';
-    if (navbar) {
-      navbar.classList.remove('navbar-dark');
-      navbar.classList.add('navbar-light');
+    const darkImage = document.getElementById('dark-image');
+    const lightImage = document.getElementById('light-image');
+    const navbar = document.querySelector('.navbar');
+    const contactLinks = document.querySelectorAll('.contact');
+
+    if (document.body.classList.contains('dark-mode')) {
+      if (darkImage) darkImage.style.display = 'block';
+      if (lightImage) lightImage.style.display = 'none';
+      if (navbar) {
+        navbar.classList.remove('navbar-dark');
+        navbar.classList.add('navbar-light');
+      }
+
+      contactLinks.forEach((link) => {
+        link.classList.remove('text-dark');
+        link.classList.add('text-white');
+      });
+    } else {
+      if (darkImage) darkImage.style.display = 'none';
+      if (lightImage) lightImage.style.display = 'block';
+      if (navbar) {
+        navbar.classList.remove('navbar-light');
+        navbar.classList.add('navbar-dark');
+      }
+
+      contactLinks.forEach((link) => {
+        link.classList.remove('text-white');
+        link.classList.add('text-dark');
+      });
     }
+  });
+}
 
-    contact.forEach(link => {
-      link.classList.remove('text-dark')
-      link.classList.add('text-white')
-    });
-
-
-  } else {
-    // Show light image, hide dark image
-    if (darkImage) darkImage.style.display = 'none';
-    if (lightImage) lightImage.style.display = 'block';
-    if (navbar) {
-      navbar.classList.remove('navbar-light');
-      navbar.classList.add('navbar-dark');
-    }
-
-    contact.forEach(link => {
-      link.classList.remove('text-white')
-      link.classList.add('text-dark')
-    });
-  }
-});
+document.addEventListener('DOMContentLoaded', initializeDarkModeToggle);
+document.addEventListener('turbo:load', initializeDarkModeToggle);


### PR DESCRIPTION
## Summary
- wrap the dark mode toggle setup in an initializer that runs on DOMContentLoaded and turbo:load
- guard against missing toggle elements and duplicate listener bindings via a dataset flag
- re-query dependent DOM nodes on each click before applying class toggles

## Testing
- bin/rails server -b 0.0.0.0 -p 3000 *(fails: Ruby version mismatch with Gemfile requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf87576d0832a9522a319beabd594