### PR TITLE
Fix Chrono Crow Unity container mobile positioning

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -303,6 +303,30 @@ a:hover {
   width: 100%;
 }
 
+.chrono-crow-page #unity-container,
+.chrono-crow-page #unity-container.unity-mobile,
+.chrono-crow-page .unity-mobile #unity-container {
+  position: relative !important;
+  width: 100% !important;
+  height: 100% !important;
+  top: auto !important;
+  right: auto !important;
+  bottom: auto !important;
+  left: auto !important;
+  margin: 0 !important;
+}
+
+.chrono-crow-page .chrono-crow-player-frame {
+  position: relative;
+}
+
+.chrono-crow-page .chrono-crow-player-frame #unity-canvas,
+.chrono-crow-page .chrono-crow-player-frame canvas {
+  position: relative !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+
 #unity-container #unity-footer {
   gap: 1rem;
 }


### PR DESCRIPTION
## Summary
- override Unity mobile styles specifically for the Chrono Crow page so the container stays inside the player frame
- ensure the Unity canvas and container respect the frame dimensions even when inline fixed positioning is applied

## Testing
- not run (ruby 3.2.3 available in environment but project requires 3.1.2)


------
https://chatgpt.com/codex/tasks/task_e_68df0abd0410832ab143059dde462e7b