### PR TITLE
Add dedicated mobile fullscreen control for Chrono Crow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -198,6 +198,57 @@ a:hover {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.chrono-crow-player-frame {
+  position: relative;
+}
+
+.chrono-crow-mobile-fullscreen-control {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  display: none;
+  z-index: 20;
+}
+
+.chrono-crow-fullscreen-button {
+  appearance: none;
+  border: none;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.chrono-crow-fullscreen-button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.chrono-crow-fullscreen-button:focus,
+.chrono-crow-fullscreen-button:hover {
+  background: rgba(255, 255, 255, 0.15);
+  transform: translateY(-1px);
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.unity-mobile + .chrono-crow-mobile-fullscreen-control,
+.unity-mobile ~ .chrono-crow-mobile-fullscreen-control {
+  display: flex;
+}
+
+@media (min-width: 992px) {
+  .chrono-crow-mobile-fullscreen-control {
+    display: none !important;
+  }
+}
+
 .emirates-page {
   background: linear-gradient(135deg, #0f1a2d 0%, #162544 60%, #1e3358 100%);
   color: #f5f7ff;

--- a/app/views/pages/chrono_crow.html.erb
+++ b/app/views/pages/chrono_crow.html.erb
@@ -15,6 +15,11 @@
         <div id="unity-mobile-warning">Best experienced in landscape orientation on mobile.</div>
       </div>
     </div>
+    <div class="chrono-crow-mobile-fullscreen-control">
+      <button type="button" class="chrono-crow-fullscreen-button" aria-label="Enter fullscreen">
+        Fullscreen
+      </button>
+    </div>
   </div>
   <script src="<%= @chronocrow_loader_path %>"></script>
   <script>
@@ -24,8 +29,14 @@
     const loadingBar = document.querySelector('#unity-loading-bar');
     const progressBarFull = document.querySelector('#unity-progress-bar-full');
     const fullscreenButton = document.querySelector('#unity-fullscreen-button');
+    const mobileFullscreenButton = document.querySelector('.chrono-crow-fullscreen-button');
+    const mobileFullscreenControl = document.querySelector('.chrono-crow-mobile-fullscreen-control');
     const warningBanner = document.querySelector('#unity-warning');
     warningBanner.style.display = 'none';
+
+    if (mobileFullscreenButton) {
+      mobileFullscreenButton.disabled = true;
+    }
 
     function updateBannerVisibility() {
       warningBanner.style.display = warningBanner.children.length ? 'block' : 'none';
@@ -76,6 +87,10 @@
         container.classList.remove('unity-mobile');
       }
 
+      if (mobileFullscreenControl) {
+        mobileFullscreenControl.style.display = isMobile ? 'flex' : 'none';
+      }
+
       const frameRect = frame.getBoundingClientRect();
       const frameHeight = frameRect.height || (frameRect.width / aspectRatio);
       config.devicePixelRatio = pixelRatio;
@@ -99,6 +114,12 @@
         fullscreenButton.onclick = () => {
           unityInstance.SetFullscreen(1);
         };
+        if (mobileFullscreenButton) {
+          mobileFullscreenButton.disabled = false;
+          mobileFullscreenButton.addEventListener('click', () => {
+            unityInstance.SetFullscreen(1);
+          });
+        }
       })
       .catch((message) => {
         unityShowBanner(message, 'error');


### PR DESCRIPTION
## Summary
- add a dedicated Chrono Crow fullscreen control outside the Unity footer so it remains visible on mobile
- hook the new control into the Unity instance once it loads to trigger fullscreen just like the desktop button
- style the overlay control for mobile positioning while hiding it on larger breakpoints

## Testing
- not run (Ruby 3.2.3 available but project requires 3.1.2)


------
https://chatgpt.com/codex/tasks/task_e_68df0abce210832ab976161f08ce603b