### PR TITLE
Scope Chrono Crow mobile overrides to unity-mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -354,7 +354,6 @@ a:hover {
   width: 100%;
 }
 
-.chrono-crow-page #unity-container,
 .chrono-crow-page #unity-container.unity-mobile,
 .chrono-crow-page .unity-mobile #unity-container {
   position: relative !important;
@@ -371,8 +370,10 @@ a:hover {
   position: relative;
 }
 
-.chrono-crow-page .chrono-crow-player-frame #unity-canvas,
-.chrono-crow-page .chrono-crow-player-frame canvas {
+.chrono-crow-page #unity-container.unity-mobile #unity-canvas,
+.chrono-crow-page #unity-container.unity-mobile canvas,
+.chrono-crow-page .unity-mobile #unity-container #unity-canvas,
+.chrono-crow-page .unity-mobile #unity-container canvas {
   position: relative !important;
   width: 100% !important;
   height: 100% !important;


### PR DESCRIPTION
## Summary
- limit the Chrono Crow player container overrides to cases where the unity-mobile class is present
- scope canvas sizing adjustments to the unity-mobile context to avoid interfering with desktop centering

## Testing
- not run (explanation: browser-based verification not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df48424ca4832aa20f53ba0b247afc